### PR TITLE
(Des)Criptografar com parametro pela linha de comando.

### DIFF
--- a/Engine.c
+++ b/Engine.c
@@ -40,13 +40,13 @@
 /*Funç~ao que recebe os parametros passado pelo usuario e realiza testes*/
 int treatment(int argc, char **argv){
 
-    if(argc == 2){
+    if(argc == 3){
         return 1;
     }
     else
     {
-        printf("Nao foi recebido um arquivo como parametro\nPrograma encerrado!!\n");
-        exit(0);
+        printf("\nCubiX usage: ./main [-c | -d] filename");
+	exit(0);
     }
 }
 

--- a/main.c
+++ b/main.c
@@ -59,11 +59,14 @@ int main(int argc, char *argv[]){
 
 	/*Inicio*/
 	treatment(argc, argv); //Testa parametros recebidos
-	texto_puro = argv[1];
-
-	/*Menu de opcoes*/
-	menu();
-	scanf("%d",&op);
+	if(strcmp(argv[1],"-c") == 0) {
+		op = 1;
+	} else if(strcmp(argv[1],"-d") == 0) {
+                op = 2;
+        } else {
+		return -1;
+	}
+	texto_puro = argv[2];
 
 	switch(op){
 		case 1: 


### PR DESCRIPTION
Adicionei um termo como parâmetro na linha de comando para criptografar ou descriptografar, ao invés de exibir o menu com opção. O que acha?

Use -c para criptografar e -d para descriptografar.

Em caso de número incorreto de argumentos exibe a seguinte mensagem:
`CubiX usage: ./main [-c | -d] filename`

Quero trabalhar em outros parâmetros para exibição de debug ou não, por exemplo.
E, claro, fazer os tratamentos de erro dessas entradas.
